### PR TITLE
Add optional regex to enforce password complexity

### DIFF
--- a/bin/dialog_wrapper.py
+++ b/bin/dialog_wrapper.py
@@ -96,20 +96,25 @@ class Dialog:
                                        no_cancel=True)
         return choice
 
-    def get_password(self, title, text, min_length=1):
+    def get_password(self, title, text, pass_req=6):
         def ask(title, text):
             return self.wrapper('passwordbox', text, title=title,
                                 ok_label='OK', no_cancel='True')[1]
 
         while 1:
             password = ask(title, text)
-            if len(password) < min_length:
-                error = "Password must be at least %s characters." % min_length
-                if not password:
-                    error = "Please enter non-empty password."
-
-                self.error(error)
+            if not password:
+                self.error("Please enter non-empty password.")
                 continue
+
+            try:
+                if not re.match(pass_req, password):
+                    self.error("Password does not match complexity requirements.")
+                    continue
+            except TypeError:
+                if len(password) < pass_req:
+                    self.error("Password must be at least %s characters." % pass_req)
+                    continue
 
             if password == ask(title, 'Confirm password'):
                 return password


### PR DESCRIPTION
As discussed, with a minor change: instead of adding an additional parameter for the regex, I made the third parameter generic (pass_req) and run password validation based on type.  This keeps things backwards-compatible without cluttering up the method call.
- if pass_req is a string, assume it's a regex and test the password against that;
- if above fails with a TypeError, pass_req is an integer so we test for password length only;

Also as discussed, I set the default password requirement to minimum length 6.
