### PR TITLE
do not delete SEC_UPDATES info from inithooks.conf

### DIFF
--- a/firstboot.d/90delconf
+++ b/firstboot.d/90delconf
@@ -2,8 +2,10 @@
 
 . /etc/default/inithooks
 
+[ -e $INITHOOKS_CONF ] && . $INITHOOKS_CONF
+
 # blank out configuration file (usually contains passwords)
-[ -e $INITHOOKS_CONF ] && echo > $INITHOOKS_CONF
+[ -e $INITHOOKS_CONF ] && echo "SEC_UPDATES=$SEC_UPDATES" > $INITHOOKS_CONF
 
 exit 0
 

--- a/firstboot.d/95secupdates
+++ b/firstboot.d/95secupdates
@@ -8,6 +8,8 @@ grep -qs boot=casper /proc/cmdline && exit 2
 LOGFILE=/var/log/cron-apt/log
 . /etc/default/inithooks
 
+[ -e $INITHOOKS_CONF ] && . $INITHOOKS_CONF
+
 install_updates() {
     for actionfile in /etc/cron-apt/action.d/*; do
         while read aptcmd; do


### PR DESCRIPTION
currently we delete the inithooks.conf before we process
the security updates scripts. This patch keeps the SEC_UPDATES
parameter and makes it possible to override the setting
in /etc/default/inithooks with the setting in the custom
/etc/inithooks.conf file.

Signed-off-by: Peter Lieven pl@kamp.de
