### PR TITLE
introduce ROOT_USER

### DIFF
--- a/firstboot.d/30rootpass
+++ b/firstboot.d/30rootpass
@@ -4,5 +4,9 @@
 . /etc/default/inithooks
 
 [ -e $INITHOOKS_CONF ] && . $INITHOOKS_CONF
-$INITHOOKS_PATH/bin/setpass.py root --pass="$ROOT_PASS"
 
+if [ -n "$ROOT_USER" ]; then
+   $INITHOOKS_PATH/bin/setpass.py $ROOT_USER --pass="$ROOT_PASS"
+else
+   $INITHOOKS_PATH/bin/setpass.py root --pass="$ROOT_PASS"
+fi


### PR DESCRIPTION
this adds a ROOT_USER parameter which enables the firstboot.d/30rootpass script
to set the password for a user other than root.

Signed-off-by: Peter Lieven pl@kamp.de
