### PR TITLE
95secupdates: reboot after forced security updates

### DIFF
--- a/firstboot.d/95secupdates
+++ b/firstboot.d/95secupdates
@@ -6,7 +6,8 @@
 grep -qs boot=casper /proc/cmdline && exit 2
 
 LOGFILE=/var/log/cron-apt/log
-. /etc/default/inithooks
+INITHOOKS_DEFAULT=/etc/default/inithooks
+. $INITHOOKS_DEFAULT
 
 [ -e $INITHOOKS_CONF ] && . $INITHOOKS_CONF
 
@@ -18,6 +19,8 @@ install_updates() {
             DEBIAN_FRONTEND=noninteractive apt-get $aptcmd | tee -a $LOGFILE
         done < $actionfile
     done
+    sed -i '/RUN_FIRSTBOOT/ s/=.*/=false/g' $INITHOOKS_DEFAULT
+    exit 42
 }
 
 [ "$SEC_UPDATES" == "SKIP" ] && exit 0


### PR DESCRIPTION
some updates require a reboot. spotted on the openvpn appliance
where a kernel update breaks the tun module.

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=767836

Signed-off-by: Peter Lieven <pl@kamp.de>