### PR TITLE
Launch inithooks after basic boot has completed

### DIFF
--- a/debian/service
+++ b/debian/service
@@ -1,6 +1,7 @@
 [Unit]
 Description=inithooks: firstboot and everyboot initialization scripts
-After=getty@tty8.service
+After=basic.target getty@tty8.service
+Before=default.target
 ConditionKernelCommandLine=!noinithooks
 
 [Service]
@@ -17,4 +18,4 @@ ExecStart=/bin/sh -c '\
     chvt $FGCONSOLE'
 
 [Install]
-WantedBy=basic.target
+WantedBy=default.target


### PR DESCRIPTION
Fixes https://github.com/turnkeylinux/tracker/issues/356, https://github.com/turnkeylinux/tracker/issues/338 in my experience. Optimally would need to be tested.