### PR TITLE
Init fence fix

### DIFF
--- a/default/turnkey-init-fence
+++ b/default/turnkey-init-fence
@@ -6,4 +6,5 @@ RUNAS=nobody
 
 HTTP_FENCE_PORT=60080
 HTTPS_FENCE_PORT=60443
-HTTPS_FENCE_CERTFILE=/etc/ssl/certs/cert.pem
+HTTPS_FENCE_CERTFILE=/etc/ssl/private/cert.pem
+HTTPS_FENCE_KEYFILE=/etc/ssl/private/cert.key

--- a/turnkey-init-fence/turnkey-init-fence
+++ b/turnkey-init-fence/turnkey-init-fence
@@ -93,7 +93,7 @@ do_start()
     start-stop-daemon --start --quiet --pidfile $PIDFILE --name $(basename $DAEMON) --startas $DAEMON --test > /dev/null \
 		|| return 1
 	start-stop-daemon --start --pidfile $PIDFILE --exec $DAEMON -- --runas=$RUNAS \
-        --daemonize=$PIDFILE $WEBROOT $HTTP_FENCE_PORT $HTTPS_FENCE_PORT $HTTPS_FENCE_CERTFILE
+        --daemonize=$PIDFILE $WEBROOT $HTTP_FENCE_PORT $HTTPS_FENCE_PORT $HTTPS_FENCE_CERTFILE $HTTPS_FENCE_KEYFILE
 
 	# Add code here, if necessary, that waits for the process to be ready
 	# to handle requests from services started subsequently which depend


### PR DESCRIPTION
Due to the SSL changes (cert.pem is now just the certificate, without the key), the old simplehttpd script would not work which left fresh instances fenceless and broke the inithooks command sequence. This should remedy the issue.