### PR TITLE
get CODENAME more reliably

### DIFF
--- a/firstboot.d/30turnkey-init-fence
+++ b/firstboot.d/30turnkey-init-fence
@@ -8,7 +8,7 @@ USERNAME=root
 PROFILE_FIRSTLOGIN=$(eval printf ~$USERNAME)/.profile.d/turnkey-init-fence
 [ -f $PROFILE_FIRSTLOGIN ] && chmod +x $PROFILE_FIRSTLOGIN
 
-CODENAME=$(cat /etc/hostname)
+CODENAME=$(turnkey-version | cut -d- -f2)
 sed -i "s/\$CODENAME/$CODENAME/" /var/lib/inithooks/turnkey-init-fence/htdocs/index.html
 
 update-rc.d turnkey-init-fence defaults


### PR DESCRIPTION
I forget exactly where this was an issue but I did have an experience where using the hostname as the CODENAME didn't match so the link on the fence html didn't work.

This resolves that.