### PR TITLE
Added msg to initfence and suppressed an error

### DIFF
--- a/firstboot.d/29tagid
+++ b/firstboot.d/29tagid
@@ -20,6 +20,8 @@ EOF
 	
 fi
 
+[ -d /var/www ] || exit 0
+
 ### control panel - tag the first index we find
 for index in $(find /var/www -name 'index.*' ); do
 

--- a/firstboot.d/30turnkey-init-fence
+++ b/firstboot.d/30turnkey-init-fence
@@ -12,3 +12,4 @@ PROFILE_FIRSTLOGIN=$(eval printf ~$USERNAME)/.profile.d/turnkey-init-fence
 
 update-rc.d turnkey-init-fence defaults
 /etc/init.d/turnkey-init-fence start
+echo 'turnkey-init-fence is up'

--- a/firstboot.d/97turnkey-init-fence-disable
+++ b/firstboot.d/97turnkey-init-fence-disable
@@ -14,3 +14,5 @@ for home in /root /home/admin; do
 done
 
 chmod -x /usr/lib/inithooks/firstboot.d/??turnkey-init-fence*
+
+echo 'turnkey-init-fence is down'


### PR DESCRIPTION
Added message to turnkey-init-fence to show whether it's up or down
as well as suppressed an error in inithooks on core by exiting
cleanly if error would occur.

Closes https://github.com/turnkeylinux/tracker/issues/570