### PR TITLE
Ensure sudoadmin is enabled on rootfs of EC2 builds, disabled when deploying to the Hub

### DIFF
--- a/firstboot.d/29sudoadmin
+++ b/firstboot.d/29sudoadmin
@@ -5,5 +5,7 @@
 . /etc/default/inithooks
 if [ "$(echo $SUDOADMIN | tr [A-Z] [a-z] )" = "true" ]; then
     turnkey-sudoadmin on --disable-setpass
+elif [ "$(echo $SUDOADMIN | tr [A-Z] [a-z] )" = "false" ]; then
+    turnkey-sudoadmin off --disable-setpass
 fi
 

--- a/turnkey-sudoadmin
+++ b/turnkey-sudoadmin
@@ -28,7 +28,7 @@ On:
     - locks the root user
     - disables root ssh access
     - sets root ssh login banner
-    - restarts ssh daemon
+    - restarts ssh daemon, if it is running
     - sets admin password interactively (unless --disable-setpass)
 
 Off:
@@ -38,7 +38,7 @@ Off:
     - enables root ssh access
     - locks admin user
     - unsets root ssh login banner
-    - restarts ssh daemon
+    - restarts ssh daemon, if it is running
     - sets root password interactively (unless --disable-setpass)
 
 EOF
@@ -172,7 +172,9 @@ user_state() {
 
 restart_sshd() {
     info $FUNCNAME $@
-    /etc/init.d/ssh status >/dev/null && /etc/init.d/ssh restart
+    if [ -e /var/run/sshd.pid ]; then
+        /etc/init.d/ssh restart
+    fi
 }
 
 setpass() {


### PR DESCRIPTION
Honestly, I am not completely sure if what I did in 29sudoadmin here is right. It seems to me that overall depending on ```SUDOADMIN``` to turn it on/off but also writing the boolean value to /etc/default/inithooks [as part](https://github.com/turnkeylinux/inithooks/blob/master/turnkey-sudoadmin#L74) of what ```turnkey-sudoadmin``` does is a bit redundant but I thought there probably is a rationale for having a separate 29sudoadmin and it did not feel right to simply reverse the conditional (so it disables turnkey-sudoadmin if ```SUDOADMIN=false```, does nothing otherwise).

Anyway, it worked correctly on EC2 and the Hub so this is mostly a question of style. Input on the above welcome.

Depends on https://github.com/turnkeylinux/buildtasks/pull/19