### PR TITLE
Add hostname to dhcp requests

### DIFF
--- a/firstboot.d/01ipconfig
+++ b/firstboot.d/01ipconfig
@@ -8,33 +8,56 @@
 [ "$IP_CONFIG" != "manual" ] && [ "$IP_CONFIG" != "static" ] && [ "$IP_CONFIG" != "dhcp" ] && exit 1
 [ ! -e /etc/network/interfaces ] && exit 1
 
+APP=$(turnkey-version | cut -d "-" -f 2)
+
+IP_IFACE="eth0"
+[ "$APP" == "lxc" ] && IP_IFACE="br0"
+
 # if IP_CONFIG is not changed skip this script and avoid a interface reconfiguration
-grep "iface eth0 inet $IP_CONFIG" /etc/network/interfaces >/dev/null && exit 0
+grep "iface $IP_IFACE inet $IP_CONFIG" /etc/network/interfaces >/dev/null && exit 0
 
 ifdown --exclude=lo -a
 
 # since debian 8 (systemd) ifdown does no longer take the interface down
 # if we change between manual, static or dhcp this does not work anymore
 # as ifup won't do anything
-ip link set eth0 down
+ip link set $IP_IFACE down
 
-echo "# interfaces(5) file used by ifup(8) and ifdown(8)" >/etc/network/interfaces
-echo >>/etc/network/interfaces
-echo "auto lo" >>/etc/network/interfaces
-echo "iface lo inet loopback" >>/etc/network/interfaces
-echo >>/etc/network/interfaces
-echo "auto eth0" >>/etc/network/interfaces
-echo "iface eth0 inet $IP_CONFIG" >>/etc/network/interfaces
+# remove modified or unecessary options, regardless of order
+  sed -i "/auto $IP_IFACE/,/^$/ {
+  /hostname/ d
+  /address/ d
+  /netmask/ d
+  /gateway/ d
+  /dns-nameservers/ d
+  }" /etc/network/interfaces
 
-if [ "$IP_CONFIG" = "dhcp" ]; then
- echo " hostname $HOSTNAME" >>/etc/network/interfaces
+# configure 'manual' interface
+if [ "$IP_CONFIG" = "manual" ]; then
+  sed -i "/auto $IP_IFACE/,/^$/ {
+  /iface/ s/[^ ]*$/manual/
+  }" /etc/network/interfaces
 fi
 
+# configure 'dhcp' interface
+if [ "$IP_CONFIG" = "dhcp" ]; then
+  sed -i "/auto $IP_IFACE/,/^$/ {
+  /iface/ s/[^ ]*$/dhcp/
+  /iface/ a\\
+    hostname $HOSTNAME
+  }" /etc/network/interfaces
+fi
+
+# configure 'static' interface
 if [ "$IP_CONFIG" = "static" ]; then
- echo " address $IP_ADDRESS" >>/etc/network/interfaces
- echo " netmask $IP_NETMASK" >>/etc/network/interfaces
- echo " gateway $IP_GW" >>/etc/network/interfaces
- echo " dns-nameservers $IP_DNS1 $IP_DNS2" >>/etc/network/interfaces
+  sed -i "/auto $IP_IFACE/,/^$/ {
+  /iface/ s/[^ ]*$/static/
+  /iface/ a\\
+    address $IP_ADDRESS\\
+    netmask $IP_NETMASK\\
+    gateway $IP_GW\\
+    dns-nameservers $IP_DNS1 $IP_DNS2
+  }" /etc/network/interfaces
 fi
 
 ifup --exclude=lo -a

--- a/firstboot.d/01ipconfig
+++ b/firstboot.d/01ipconfig
@@ -26,6 +26,10 @@ echo >>/etc/network/interfaces
 echo "auto eth0" >>/etc/network/interfaces
 echo "iface eth0 inet $IP_CONFIG" >>/etc/network/interfaces
 
+if [ "$IP_CONFIG" = "dhcp" ]; then
+ echo " hostname $HOSTNAME" >>/etc/network/interfaces
+fi
+
 if [ "$IP_CONFIG" = "static" ]; then
  echo " address $IP_ADDRESS" >>/etc/network/interfaces
  echo " netmask $IP_NETMASK" >>/etc/network/interfaces

--- a/firstboot.d/01ipconfig
+++ b/firstboot.d/01ipconfig
@@ -8,7 +8,7 @@
 [ "$IP_CONFIG" != "manual" ] && [ "$IP_CONFIG" != "static" ] && [ "$IP_CONFIG" != "dhcp" ] && exit 1
 [ ! -e /etc/network/interfaces ] && exit 1
 
-APP=$(turnkey-version | cut -d "-" -f 2)
+APP=$(turnkey-version | sed 's/turnkey-\(.*\)-[0-9]\+\.[0-9]\+-.*$/\1/')
 
 IP_IFACE="eth0"
 [ "$APP" == "lxc" ] && IP_IFACE="br0"

--- a/firstboot.d/09hostname
+++ b/firstboot.d/09hostname
@@ -14,6 +14,7 @@ for file in \
    /etc/printcap \
    /etc/hostname \
    /etc/hosts \
+   /etc/network/interfaces \
    /etc/ssh/ssh_host_rsa_key.pub \
    /etc/ssh/ssh_host_dsa_key.pub \
    /etc/ssh/ssh_host_ecdsa_key.pub \


### PR DESCRIPTION
Adds the `hostname` to `dhcp` interfaces in `/etc/network/interfaces`.
@plieven - I had to do a major rewrite of your `01ipconfig` to make it compatible with `confconsole` and the `LXC` appliance.  I hope I achieved your original intent to allow pre-seeding of the `HOSTNAME` and IP4 configuration while preserving additional options used by some appliances, e.g. `LXC`