### PR TITLE
Create TurnKey initfence systemd service file.

### DIFF
--- a/debian/install
+++ b/debian/install
@@ -6,6 +6,7 @@ run                 /usr/lib/inithooks
 rsyslog.d/*         /etc/rsyslog.d
 
 turnkey-init-fence/turnkey-init-fence /etc/init.d
+turnkey-init-fence/turnkey-init-fence.service /lib/systemd/system
 turnkey-init-fence/htdocs /var/lib/inithooks/turnkey-init-fence
 
 turnkey-init                        /usr/sbin

--- a/turnkey-init-fence/turnkey-init-fence.service
+++ b/turnkey-init-fence/turnkey-init-fence.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=TurnKey Initialization Fence - Fences off appliance ports until after initialization...
+Requires=local-fs.target
+After=network.target remote-fs.target nss-lookup.target
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/default/turnkey-init-fence
+ExecStart=/usr/bin/python3 /usr/lib/inithooks/bin/simplehttpd.py \
+              --runas="${RUNAS}" "${WEBROOT}" \
+              "${HTTP_FENCE_PORT}" "${HTTPS_FENCE_PORT}" \
+              "${HTTPS_FENCE_CERTFILE}" "${HTTPS_FENCE_KEYFILE}"


### PR DESCRIPTION
Add in a native systemd service file for `turnkey-init-fence` - previously only had sysvinit script (i.e. `/etc/init.d` script).