### PR TITLE
Force pybuild to not create __pycache__ files at build

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,8 +1,11 @@
 #! /usr/bin/make -f
+
 export PYBUILD_BEFORE_BUILD=\
 	echo usr/lib/python{version.major}/dist-packages/libinithooks/inithooks_cache.py \
 	usr/lib/inithooks/bin/inithooks_cache.py \
 	> debian/inithooks.links
+
+export PYTHONDONTWRITEBYTECODE=1
 
 %:
 	dh $@ --with=python3 --buildsystem=pybuild


### PR DESCRIPTION
Minimal change to make inithooks reproducible.