### PR TITLE
Start up improvements

### DIFF
--- a/bin/simplehttpd.py
+++ b/bin/simplehttpd.py
@@ -211,13 +211,14 @@ class SimpleWebServer:
                 (https_conf.host, https_conf.port), self.HTTPRequestHandler
             )
 
-            httpsd.socket = ssl.wrap_socket(
-                httpsd.socket,
-                certfile=certfile,
-                keyfile=keyfile,
-                server_side=True,
-                ssl_version=ssl.PROTOCOL_TLSv1_2,
-                ciphers=https_conf.CIPHERS,
+            context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+            context.load_cert_chain(certfile=certfile, keyfile=keyfile)
+            context.minimum_version = ssl.TLSVersion.TLSv1_2
+            context.maximum_version = ssl.TLSVersion.TLSv1_3
+            context.set_ciphers(https_conf.CIPHERS)
+
+            httpsd.socket = context.wrap_socket(
+                httpsd.socket, server_side=True,
             )
 
         if runas:

--- a/bin/simplehttpd.py
+++ b/bin/simplehttpd.py
@@ -75,7 +75,8 @@ def daemonize(pidfile: str, logfile: str | None = None) -> None:
 
     pid = os.fork()
     if pid != 0:
-        print(str(pid), file=open(pidfile, "w").close())
+        with open(pidfile, "w") as fob:
+            fob.write(str(pid))
         sys.exit(0)
 
     os.chdir("/")
@@ -89,7 +90,7 @@ def daemonize(pidfile: str, logfile: str | None = None) -> None:
 
 
 class SecureHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
-    ALLOWED_EXTS = []
+    ALLOWED_EXTS: list[str] = []
 
     def list_directory(self, path: os.PathLike | str) -> None:
         _ = path
@@ -117,17 +118,17 @@ class SimpleWebServer:
         @staticmethod
         def parse_address(address: str) -> tuple[str, int]:
             if ":" in address:
-                host, port = address.split(":", 1)
+                host, _port = address.split(":", 1)
             else:
                 host = "0.0.0.0"
-                port = address
+                _port = address
 
             try:
-                port = int(port)
+                port = int(_port)
                 assert port > 0 and port < 65535
             except (ValueError, AssertionError):
                 raise SimpleWebServerError(
-                    f"Illegal port: '{port}' - must be integer between 1 &"
+                    f"Illegal port: '{_port}' - must be integer between 1 &"
                     " 65534"
                 )
             return host, port

--- a/bin/turnkey-init-fence
+++ b/bin/turnkey-init-fence
@@ -125,11 +125,13 @@ case "$1" in
         echo "Starting turnkey-init-fence"
         iptables_redirect start
         start_mini_server
+        echo "Started turnkey-init-fence"
         ;;
     stop)
         echo "Stopping turnkey-init-fence"
         iptables_redirect stop
         stop_mini_server
+        echo "Stopped turnkey-init-fence"
         ;;
     *)
         echo "Unknown command: $1" >&2

--- a/bin/turnkey-init-fence
+++ b/bin/turnkey-init-fence
@@ -9,6 +9,7 @@ DEBUG=${DEBUG:-}
 HTDOCS=lib/inithooks/turnkey-init-fence/htdocs
 PIDFILE=/run/init-fence.pid
 LOGFILE=/var/log/init-fence.log
+SERVER_RUNAS=nobody
 
 # shellcheck source=default/turnkey-init-fence
 source /etc/default/turnkey-init-fence
@@ -75,20 +76,20 @@ iptables_redirect() {
 }
 
 start_mini_server() {
+    local htdocs
     if [[ -d "/var/$HTDOCS" ]]; then
-        HTDOCS="/var/$HTDOCS"
+        htdocs="/var/$HTDOCS"
     else
-        HTDOCS="/usr/$HTDOCS"
+        htdocs="/usr/$HTDOCS"
     fi
-    chown -R nobody "$HTDOCS"
-    echo "Starting init-fence mini-server (serving $HTDOCS)"
+    echo "Starting init-fence mini-server (serving $htdocs)"
     touch "$LOGFILE" "$PIDFILE"
-    chown nobody "$LOGFILE" "$PIDFILE"
+    chown -R "$SERVER_RUNAS" "$htdocs" "$LOGFILE" "$PIDFILE"
     /usr/lib/inithooks/bin/simplehttpd.py \
         --daemonize="$PIDFILE" \
-        --runas=nobody \
+        --runas="$SERVER_RUNAS" \
         --logfile="$LOGFILE" \
-        "$HTDOCS" \
+        "$htdocs" \
         "$HTTP_FENCE_PORT" \
         "$HTTPS_FENCE_PORT" \
         "$HTTPS_FENCE_CERTFILE" \
@@ -114,7 +115,6 @@ stop_mini_server() {
         else
             echo "<3>No simplehttpd.py process found" >&2
         fi
-
     fi
 }
 

--- a/bin/turnkey-init-fence
+++ b/bin/turnkey-init-fence
@@ -4,7 +4,7 @@
 # initialized (admin password configure, etc)
 
 HTDOCS=lib/inithooks/turnkey-init-fence/htdocs
-PIDFILE=/run/init-fence
+PIDFILE=/run/init-fence.pid
 LOGFILE=/var/log/init-fence.log
 
 # shellcheck source=default/turnkey-init-fence
@@ -78,8 +78,8 @@ start_mini_server() {
         HTDOCS="/usr/$HTDOCS"
     fi
     echo "Starting init-fence mini-server (serving $HTDOCS)"
-    touch "$LOGFILE"
-    chown nobody "$LOGFILE"
+    touch "$LOGFILE" "$PIDFILE"
+    chown nobody "$LOGFILE" "$PIDFILE"
     /usr/lib/inithooks/bin/simplehttpd.py \
         --daemonize="$PIDFILE" \
         --runas=nobody \
@@ -89,7 +89,7 @@ start_mini_server() {
         "$HTTPS_FENCE_PORT" \
         "$HTTPS_FENCE_CERTFILE" \
         "$HTTPS_FENCE_KEYFILE" \
-        | echo "<3>init-fence mini server failed to start" >&2 \
+        || echo "<3>init-fence mini server failed to start" >&2 \
         && exit 1
 }
 

--- a/bin/turnkey-init-fence
+++ b/bin/turnkey-init-fence
@@ -94,8 +94,10 @@ start_mini_server() {
         "$HTTPS_FENCE_PORT" \
         "$HTTPS_FENCE_CERTFILE" \
         "$HTTPS_FENCE_KEYFILE" \
-        || echo "<3>init-fence mini server failed to start" >&2 \
-        && exit 1
+        || {
+            echo "<3>init-fence mini server failed to start" >&2 \
+            && exit 1
+        }
 }
 
 stop_mini_server() {

--- a/bin/turnkey-init-fence
+++ b/bin/turnkey-init-fence
@@ -88,7 +88,9 @@ start_mini_server() {
         "$HTTP_FENCE_PORT" \
         "$HTTPS_FENCE_PORT" \
         "$HTTPS_FENCE_CERTFILE" \
-        "$HTTPS_FENCE_KEYFILE"
+        "$HTTPS_FENCE_KEYFILE" \
+        | echo "<3>init-fence mini server failed to start" >&2 \
+        && exit 1
 }
 
 stop_mini_server() {
@@ -96,7 +98,7 @@ stop_mini_server() {
     if [[ -f "$PIDFILE" ]]; then
         kill "$( < "$PIDFILE" )"
     else
-        echo "$PIDFILE not found" >&2
+        echo "<4>pid file '$PIDFILE' not found" >&2
     fi
 }
 

--- a/bin/turnkey-init-fence
+++ b/bin/turnkey-init-fence
@@ -101,8 +101,20 @@ stop_mini_server() {
     echo "Stopping init-fence mini-server"
     if [[ -f "$PIDFILE" ]]; then
         kill "$( < "$PIDFILE" )"
+        rm "$PIDFILE"
     else
         echo "<4>pid file '$PIDFILE' not found" >&2
+        echo "Searching for simplehttpd.py process"
+        # search for process using init-fence webroot too to avoid risk of
+        # killing unrelated simplehttpd.py instance
+        PROC="/usr/lib/inithooks/bin/simplehttpd.py.*lib/inithooks/turnkey-init-fence/htdocs"
+        if PID=$(pgrep --oldest --full "$PROC"); then
+            echo "Found simplehttpd.py (pid: $PID) - killing"
+            kill "$PID"
+        else
+            echo "<3>No simplehttpd.py process found" >&2
+        fi
+
     fi
 }
 

--- a/bin/turnkey-init-fence
+++ b/bin/turnkey-init-fence
@@ -3,6 +3,9 @@
 # TurnKey web interface fence - blocks access to web app until system is
 # initialized (admin password configure, etc)
 
+DEBUG=${DEBUG:-}
+[[ -z "$DEBUG" ]] || set -x
+
 HTDOCS=lib/inithooks/turnkey-init-fence/htdocs
 PIDFILE=/run/init-fence.pid
 LOGFILE=/var/log/init-fence.log
@@ -77,6 +80,7 @@ start_mini_server() {
     else
         HTDOCS="/usr/$HTDOCS"
     fi
+    chown -R nobody "$HTDOCS"
     echo "Starting init-fence mini-server (serving $HTDOCS)"
     touch "$LOGFILE" "$PIDFILE"
     chown nobody "$LOGFILE" "$PIDFILE"

--- a/bin/turnkey-init-fence
+++ b/bin/turnkey-init-fence
@@ -3,13 +3,17 @@
 # TurnKey web interface fence - blocks access to web app until system is
 # initialized (admin password configure, etc)
 
+HTDOCS=lib/inithooks/turnkey-init-fence/htdocs
+PIDFILE=/run/init-fence
+LOGFILE=/var/log/init-fence.log
+
 # shellcheck source=default/turnkey-init-fence
 source /etc/default/turnkey-init-fence
 
 iptables_delete_redirect() {
     local dport=$1
     local to_port=$2
-
+    echo "Removing REDIRECT firewall rule: $dport => $to_port"
     while true; do
         (2>&1 iptables -t nat -D PREROUTING -p tcp --dport "$dport" -j REDIRECT --to-port "$to_port") > /dev/null || break
     done
@@ -18,24 +22,24 @@ iptables_delete_redirect() {
 iptables_add_redirect() {
     local dport=$1
     local to_port=$2
-
+    echo "Adding REDIRECT firewall rule: $dport => $to_port"
     iptables_delete_redirect "$dport" "$to_port"
     iptables -t nat -A PREROUTING -p tcp --dport "$dport" -j REDIRECT --to-port "$to_port"
 }
 
 iptables_unensure_accept() {
-    # remove ACCEPT line for fence ports (used in appliances that have a
-    # `filter` policy of `DROP`)
+    # Used in appliances that have a `filter` policy of `DROP`
     local dport=$1
+    echo "Removing ACCEPT firewall rule for fence port: $dport"
     while true; do
         (2>&1 iptables -t filter -D INPUT -p tcp -m tcp --dport "$dport" -j ACCEPT) > /dev/null || break
     done
 }
 
 iptables_ensure_accept() {
-    # add ACCEPT line for fence ports (used in appliances that have a
-    # `filter` policy of `DROP`)
+    # Used in appliances that have a `filter` policy of `DROP`
     local dport=$1
+    echo "Adding ACCEPT firewall rule for fence port: $dport"
     iptables_unensure_accept "$dport"
     iptables -t filter -A INPUT -p tcp -m tcp --dport "$dport" -j ACCEPT
 }
@@ -67,14 +71,45 @@ iptables_redirect() {
     $mop "$HTTPS_FENCE_PORT"
 }
 
+start_mini_server() {
+    if [[ -d "/var/$HTDOCS" ]]; then
+        HTDOCS="/var/$HTDOCS"
+    else
+        HTDOCS="/usr/$HTDOCS"
+    fi
+    echo "Starting init-fence mini-server (serving $HTDOCS)"
+    touch "$LOGFILE"
+    chown nobody "$LOGFILE"
+    /usr/lib/inithooks/bin/simplehttpd.py \
+        --daemonize="$PIDFILE" \
+        --runas=nobody \
+        --logfile="$LOGFILE" \
+        "$HTDOCS" \
+        "$HTTP_FENCE_PORT" \
+        "$HTTPS_FENCE_PORT" \
+        "$HTTPS_FENCE_CERTFILE" \
+        "$HTTPS_FENCE_KEYFILE"
+}
+
+stop_mini_server() {
+    echo "Stopping init-fence mini-server"
+    if [[ -f "$PIDFILE" ]]; then
+        kill "$( < "$PIDFILE" )"
+    else
+        echo "$PIDFILE not found" >&2
+    fi
+}
+
 case "$1" in
     start)
         echo "Starting turnkey-init-fence"
         iptables_redirect start
+        start_mini_server
         ;;
     stop)
         echo "Stopping turnkey-init-fence"
         iptables_redirect stop
+        stop_mini_server
         ;;
     *)
         echo "Unknown command: $1" >&2

--- a/firstboot.d/29tagid
+++ b/firstboot.d/29tagid
@@ -2,7 +2,7 @@
 
 [ -n "$_TURNKEY_INIT" ] && exit 0
 
-CODENAME=$(perl -pe 's/^turnkey-//; s/-[^-]+(-[^-]+){2}$//' < /etc/turnkey_version)
+APP_NAME=$(perl -pe 's/^turnkey-//; s/-[^-]+(-[^-]+){2}$//' < /etc/turnkey_version)
 VERSION=$(perl -pe 's/.*-([^-]+(-[^-]+){2})$/\1/' < /etc/turnkey_version)
 BUILD=$(perl -ne 'chomp; s/.*\((.*)\).*/\1/; s/^\S+ ?//; $tags=$_ ? $_ : "iso"; system("echo $tags | xargs -n 1 | sort -u | xargs echo | sed \"s/ /-/g\"");' < /etc/apt/apt.conf.d/01turnkey)
 
@@ -18,13 +18,13 @@ if [[ ! -d "/var/$FENCE_DIR" ]]; then
 fi
 
 INITFENCE_INDEX="/var/$FENCE_INDEX"
-sed -i "s/\$CODENAME/$CODENAME/" $INITFENCE_INDEX
+sed -i "s|@APP_NAME@|$APP_NAME|" $INITFENCE_INDEX
 
 if ! grep -q ajax.turnkeylinux.org $INITFENCE_INDEX; then
 
     cat>>$INITFENCE_INDEX<<EOF
-<script src="https://ajax.turnkeylinux.org/initfence/$BUILD/$VERSION/$CODENAME.js" async></script>
-<script src="https://ajax.turnkeylinux.org/initfence/$BUILD/$VERSION/$CODENAME.direct" async></script>
+<script src="https://ajax.turnkeylinux.org/initfence/$BUILD/$VERSION/$APP_NAME.js" async></script>
+<script src="https://ajax.turnkeylinux.org/initfence/$BUILD/$VERSION/$APP_NAME.direct" async></script>
 EOF
 	
 fi

--- a/firstboot.d/30turnkey-init-fence
+++ b/firstboot.d/30turnkey-init-fence
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# Note that as of v19.0, the init-fence service is enabled by default
+
 [ -n "$_TURNKEY_INIT" ] && exit 0
 
 USERNAME=root
@@ -9,7 +11,3 @@ USERNAME=root
 
 PROFILE_FIRSTLOGIN=$(eval printf ~$USERNAME)/.profile.d/turnkey-init-fence
 [ -f $PROFILE_FIRSTLOGIN ] && chmod +x $PROFILE_FIRSTLOGIN
-
-systemctl enable turnkey-init-fence
-systemctl start turnkey-init-fence
-echo 'turnkey-init-fence is up'

--- a/firstboot.d/97turnkey-init-fence-disable
+++ b/firstboot.d/97turnkey-init-fence-disable
@@ -3,10 +3,8 @@
 [ -z "$_TURNKEY_INIT" ] && exit 0; # ONLY run from within turnkey-init
 
 if systemctl is-active --quiet turnkey-init-fence; then
-
     systemctl disable turnkey-init-fence
     systemctl stop turnkey-init-fence
-
 fi
 
 for home in /root /home/admin; do

--- a/run
+++ b/run
@@ -28,6 +28,16 @@ mkdir -p "$(dirname "$INITHOOKS_LOGFILE")"
 touch "$INITHOOKS_LOGFILE"
 chmod 640 "$INITHOOKS_LOGFILE"
 
+# wait up to 10 secs for system to be running before starting; minimizes chance
+# of journal overwriting inithook dialog/confconsole
+logger -t inithooks "systemctl is-system-running: $(systemctl is-system-running)"
+for count in {1..10}; do
+    if [[ "$(systemctl is-system-running)" == "starting" ]]; then
+        logger -t inithooks "Waiting for boot to finish ($count/10 seconds)"
+        sleep 1
+    fi
+done
+
 everyboot_ran() {
     # read lastboot time
     lastboot_time="$(date '+%s' -d "$(cut -f1 -d. /proc/uptime) seconds ago")"

--- a/turnkey-init-fence/htdocs/index.html
+++ b/turnkey-init-fence/htdocs/index.html
@@ -5,18 +5,27 @@
 </head>
 
 <body>
+
+<div id="please-initialize">
   <h1>Please initialize this system...</h1>
 
-  <p>Welcome to TurnKey! You need to initialize this system first before
-  you can use it. To do that you'll need to log into the root account via SSH.
-  The <i>turnkey-init</i> initialization program should start
-  automatically:</p>
+  <p>Welcome to your TurnKey <strong>@APP_NAME@</strong> appliance!</p>
+
+  <p>Before your server is fully exposed to a hostile Internet, this system needs to
+    be initialized. This will setup passwords, install security updates, etc.</p>
+
+  <p>To initialize the system, you need to log into the "<b>root</b>" account via SSH.</p>
+
+  <p>The <i>turnkey-init</i> initialization program should start automatically:</p>
 
   <img src="/turnkey-init-root.png" />
 
-  <p>After initialization try reloading this page. This message should
-  disappear and you'll be able to access all services on this system
-  normally.</p>
+  <p>After initialization reload this page. Instead of this message, you'll be able
+    to access your server as expected.</p>
+
+</div>
+
+<div id="howto-ssh">
 
   <h2>Can I log in without SSH?</h2>
 
@@ -24,27 +33,40 @@
 
   <h2>How do I log in via SSH?</h2>
 
-  <p>If you are connecting from Linux or MacOS, please open your terminal app
-  and type the command:</p>
+  <p>The recommended SSH client is OpenSSH - although there are other options. On Windows, you may need to
+    <a href="https://docs.microsoft.com/en-us/windows-server/administration/openssh/openssh_install_firstuse?pivots=windows-11">
+    set up OpenSSH first</a>. On Linux and MacOS it should already be available.</p>
 
-  <pre id="p1">ssh example</pre>
+  <h4>SSH with a password</h4>
+  <p>If you set a root password pre-launch, open a terminal and type the command:</p>
 
-  <p>If you are connecting from Windows, you will need to install an SSH client, such as
-  <a href="https://docs.microsoft.com/en-us/windows-server/administration/openssh/openssh_install_firstuse">OpenSSH</a>
-  or <a href="https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html">PuTTY</a>.
-  Then connect to: <strong id="p2">IP ADDRESS OR FQDN</strong></p>
+  <pre id="p1">ssh root@example.com</pre>
 
-  <p>Note: to log in via SSH, you will need to have set a root password, or configured
-  SSH keys.</p>
+  <p>Then enter your password.</p>
 
-  <h2>For more information, visit our website!</h2>
+  <h4>SSH with a key pair</h4>
 
-  <p>For further information regarding this appliance, please consult the
-  <a href="https://www.turnkeylinux.org/$CODENAME">product page</a> on
-  the <a href="https://www.turnkeylinux.org">TurnKey GNU/Linux</a> website.<br>
-  For support, questions and/or feedback, please open a new thread in the
-  <a href="https://www.turnkeylinux.org/forum">TurnKey Linux forums</a> (requires
-  free website user account).</p>
+  <p>If you registered a key-pair pre-launch, you may need to provide the path to your
+    private key as well. Do that with the <i>-i</i> switch - like this:</p>
+
+  <pre id="p2">ssh -i path/to/private/key root@example.com</pre>
+
+  <h4>Complete initialization</h4>
+
+  <p>Then complete the initialization steps as prompted.</p>
+
+  <p>Once your server has been initialized, reloading this page - or browsing to
+    <strong id="p3">https://example.com</strong> - will take you to your server's main
+    page.</p>
+
+  <h2>More information and support</h2>
+
+  <p>For further information regarding TurnKey @APP_NAME@, please consult the
+  <a href="https://www.turnkeylinux.org/@APP_NAME@">appliance product page</a> on
+  the <a href="https://www.turnkeylinux.org">TurnKey GNU/Linux</a> website.</p>
+
+  <p>For support, questions and/or feedback, please <a
+        href="https://www.turnkeylinux.org/contact">contact us</a>.</p>
 
 </body>
 </html>
@@ -52,5 +74,6 @@
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
 <script>
     document.getElementById("p1").innerHTML = "ssh root@" + document.domain;
-    document.getElementById("p2").innerHTML = document.domain;
+    document.getElementById("p2").innerHTML = "ssh -i path/to/private/key root@" + document.domain;
+    document.getElementById("p3").innerHTML = "https://" + document.domain;
 </script>


### PR DESCRIPTION
Most of this PR is specifically related to the init-fence, however there is also a tweak to reduce chance of the final boot steps overwriting the inithooks or confconsole page.

Overview:
- init-fence `htdocs/index.html`
  - update/reword text for clarity and additional info
  - minor layout changes
  - update appliance substitution placeholder to `@APP_NAME@` (was `$CODENAME`)
- `firstboot.d/29tagid`
  - update appliance substitution to match changes in `htdocs/index.html`
- `firstboot.d/30turnkey-init-fence`
  - remove code that starts the init-fence (now enabled by default on all builds) - remaining code left as is as it's still needed for headless builds
- `firstboot.d/97turnkey-init-fence-disable`
  - make executable by default (to disable fence post-init)
- `bin/simplehttpd.py`
  - minor typing fixes
  - use context manager when writing the pid file
  - update `ssl.wrap_socket()` to `ssl.SSLContext().wrap_socket()` (`ssl.wrap_socket()` removed in python3.12)
- `bin/turnkey-init-fence`
  - also start/stop the mini web server
  - additional logging
- `run`
  - wait for up to 10sec for the system to finish booting to reduce chance of inithooks/confconsole being overwritten

See also https://github.com/turnkeylinux/buildtasks/pull/94