### PR TITLE
Add IPv6 support to the initfence

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,11 +38,27 @@ The configuration dialogs run in one of two places:
    Xen).  that don't provide the option to interact with the system at
    boot time.
    
-   After boot, a virtual fence redirects attempts to access
-   potentially vulnerable services to a web page explaining how to SSH
-   into the machine for the first time to initialize the system. After
+   After boot, a virtual fence redirects attempts to access potentially
+   vulnerable services to a web page explaining how to SSH into the machine
+   for the first time to initialize the system. After
    initialization the virtual fence comes down and all services can be
    accessed normally.
+
+Initialization fence
+--------------------
+
+The "initialization fence" - aka 'turnkey-init-fence' - is a mechanism which
+blocks access to the included web services until initialization is complete. It
+uses iptables to redirect attempts to access the local web server to a static
+web page served by inithooks/bin/simplehttpd.py.
+
+This page explains that you need to initialize the system before you can access
+the web interfaces. The purpose of the fence is used to prevent users from
+accessing uninitialized web applications, which in some cases can pose a
+security risk.
+
+The init-fence runs as a standalone service and is automatically disabled once
+initalization is complete.
 
 Non-interactive system initialization
 -------------------------------------
@@ -109,21 +125,24 @@ How it works
 ------------
 
 Inithooks itself is as generic and barebones as possible, leaving
-the bulk of functionality up to the appliance specific "hook"
-scripts themselves,
-
-These scripts are located in two sub-directories under
-/usr/lib/inithooks - everyboot.d and firstboot.d. 
-
-They are executed in alphanumeric ordering. This means a script named
-1-foo would be executed before 2-bar, which would itself be executed
-before 3-foobar. That's why scripts in these directories have funny
-numbers at the beginning.  
+the bulk of functionality to specific "hook" scripts.
 
 The inithooks top-level init script is executed early on in system
-initialization, at runlevel 2 15. This enables configuration of the
-system prior to most services starting. This should be taken into
-consideration when developing hook scripts.
+initialization. This enables configuration of the system prior to most services
+starting. This should be taken into consideration when developing hook scripts.
+
+The hook scripts are located in two sub-directories under /usr/lib/inithooks
+- everyboot.d and firstboot.d.
+
+They are executed in alphanumeric ordering. This means a script named 01foo
+would be executed before 20bar, which would itself be executed before 99baz.
+That's why scripts in these directories have funny numbers at numbers at the
+beginning.
+
+**IMPORTANT**: firstboot.d scripts with a prefix less than 30 should _always_
+be non-interactive. E.g. firstboot.d/29foobar should be non-interactive, but
+firstboot.d/30barbaz could be interactive. That is because interactive scripts
+running too early will likely get overwritten by boot log output.
 
 firstboot.d scripts
 '''''''''''''''''''
@@ -134,18 +153,16 @@ following conditions:
 #. If the user executes "turnkey-init" from a root shell. This command
    can be used to rerun the firstboot.d inithooks interactively to
    reconfigure the appliance if needed. Certain scripts such as those that
-   regenerate secret keys are skipped. See BLACKLIST variable in
-   /usr/sbin/turnkey-init for details.
+   regenerate secret keys are skipped.
 
 #. When the user logs in as root for the first time into a headless
    system. This triggers "turnkey-init" to run so that the user can
    interactively complete appliance initialization.
 
-#. When a TurnKey appliance boots for the first time
-
-   inithooks checks whether or not this is the first boot by checking
-   the value of the RUN\_FIRSTBOOT flag in /etc/default/inithooks. If
-   the value is false it runs the scripts and toggles the flag to true.
+#. When a TurnKey appliance boots for the first time inithooks checks whether
+   or not this is the first boot by checking the value of the RUN_FIRSTBOOT
+   flag in /etc/default/inithooks. If the value is false it runs the scripts
+   and toggles the flag to true.
 
    The firstboot scripts may run in one of two modes, interactive or
    non-interactive, depending on the type of build.
@@ -158,21 +175,21 @@ following conditions:
    application settings, etc.). These are the same scripts that get
    executed if you run "turnkey-init".
 
-   **Non-interactive mode on headless builds - OpenStack, OpenVZ,
-   OpenNode, Xen**: with these image types interactive access to the
-   virtual console during boot can not be assumed.  The first boot has
-   to be capable of running non-interactively, otherwise we risk
-   hanging the boot while it waits for user interaction that never
-   happens.
-   
+   **Non-interactive mode on headless builds - AWS, OpenStack, LXC, Xen**:
+   with these image types interactive access to the virtual console during
+   boot can not be assumed.  The first boot has to be capable of running
+   non-interactively, otherwise we risk hanging the boot while it waits for
+   user interaction that never happens.
+
    So instead of interacting with the user the system pre-initializes
    application settings with dummy defaults and set all passwords to a
    random value. If a root password has already been set (e.g., in a
    pre-deployment script) the headless preseeding script will not
    overwrite it, so your root password should work just fine.
-   
+
    The output from the non-interactive running of the firstboot
-   scripts is logged to /var/log/inithooks.log.
+   scripts is logged to /var/log/inithooks.log. Inithooks also logs to
+   the systemd journal.
 
    Interactive appliance configuration is delayed until the first time
    the user logs in as root. This is accomplished with the help of the
@@ -195,40 +212,25 @@ following conditions:
     export HUB_APIKEY=SKIP
     export SEC_ALERTS=SKIP
     export SEC_UPDATES=FORCE
+    export AUTO_RUN=TRUE
     EOF
 
     chmod +x /usr/lib/inithooks/firstboot.d/30turnkey-init-fence
 
 
-   **Initialization fence**: the above headless preseeding hook also
-   activates the "initialization fence" mechanism which uses iptables to
-   redirect attempts to access the local web server to a static web page
-   served by inithooks/bin/simplehttpd.py. 
-   
-   This page explains you need to log in as root first in order to
-   finish initializing the system. The purpose of the fence is used to
-   prevent users from accessing uninitialized web applications, which in
-   some cases can pose a security risk.
+   **Initialization fence**: After the user logs in as root and completes the
+   initialization process the "initialization fence" is turned off. Users can
+   then access applications running on the local web server.
 
-   After the user logs in as root and completes the initialization
-   process the "initialization fence" is turned off. Users can then
-   access applications running on the local web server.
+   firstboot.d/30turnkey-init-fence historically controlled the initfence,
+   however the fence now runs by default so it's only functionality is to
+   activate ~$USERNAME/.profile.d/turnkey-init-fence which launches a dtach
+   session bound to a socket. This ensures that the user is presented with
+   the interactive initialization hooks when they first log in.
 
-   What firstboot.d/30turnkey-init-fence does:
-   
-   1) enables turnkey-init-fence as a service and starts it
+   what command are we running in the dtach session?
 
-      service is enabled / disabled via update-rc.d
-
-   2) activates ~$USERNAME/.profile.d/turnkey-init-fence
-
-      the .profile.d script launches a dtach session bound to a socket
-
-          if a session is already bound to the socket attach to it
-
-          what command are we running in the dtach session?
-
-                turnkey-init -> deactivate initfence (service and profile.d)
+        turnkey-init -> deactivate initfence (service and profile.d)
 
 everyboot.d scripts
 '''''''''''''''''''
@@ -244,26 +246,36 @@ Setting the root password in a headless deployment
 On headless deployments the user needs to login as root to complete the
 appliance initialization process, but how do you login as root?
 
-Not a problem if you're using OpenNode or ProxMox - those systems
-prompt you to choose a root password before deploying a TurnKey image.
+Not a problem if you're using LXC on ProxMox or a similar system that prompts
+you to choose a root password before deploying a TurnKey image.
 
-On OpenStack you can log in as root with your configured SSH keypair
-or retrieve the random root password from the "system log". 
+On AWS or OpenStack you can log in as root with your configured SSH keypair
+or retrieve the random root password from the "system log".
 
 Other virtualization / private cloud solutions should be able to use
 their existing deployment scripts to set the root password, just like
 they already do with Debian and Ubuntu.
 
 Another more advanced option is to "preseed" the /etc/inithooks.conf
-file in the apliance's filesystem before booting it for the first
+file in the appliance's filesystem before booting it for the first
 time. This lets you leverage inithooks to pre-configure not just the
 root password but also the database and application passwords, admin
 email, domain name, etc.
 
 However note that using preseeding deactivates the "initilization
 fence". If you're using preseeding TurnKey assumes you've already
-interacted with the user some other way (e.g., web control panel) to
-get the preseeded configuration values.
+interacted with the user some other way to get the preseeded configuration
+values.
+
+If you wish to leave the init-fence running when preseeding, include this
+additional line in your preseeds file (/etc/inithooks.conf):
+
+    export AUTO_RUN=TRUE
+
+That will leave the init-fence running, but it will then need to be manually
+disabled:
+
+    systemctl disable --now turnkey-init-fence
 
 Preseeding
 ----------

--- a/bin/simplehttpd.py
+++ b/bin/simplehttpd.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 # Copyright (c) 2012-2015 Liraz Siri <liraz@turnkeylinux.org>
-# Copyright (c) 2015-2021 TurnKey GNU/Linux - https://www.turnkeylinux.org
+# Copyright (c) 2015-2026 TurnKey GNU/Linux - https://www.turnkeylinux.org
 
 """
 Simple HTTP server
@@ -25,6 +25,7 @@ Known bugs:
 import os
 from os.path import exists, abspath, isdir, splitext
 from tempfile import NamedTemporaryFile
+import socket
 import sys
 import getopt
 from typing import NoReturn
@@ -110,6 +111,12 @@ class SecureHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
 class SimpleWebServer:
     class TCPServer(socketserver.ForkingTCPServer):
         allow_reuse_address = True
+        address_family = socket.AF_INET6  # enables IPv6
+
+        def server_bind(self):
+            # Disable IPV6_V6ONLY so the socket accepts IPv4 too (dual-stack)
+            self.socket.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
+            super().server_bind()
 
     class HTTPRequestHandler(SecureHTTPRequestHandler):
         ALLOWED_EXTS = ["css", "gif", "html", "js", "png", "jpg", "txt"]
@@ -117,12 +124,62 @@ class SimpleWebServer:
     class Address:
         @staticmethod
         def parse_address(address: str) -> tuple[str, int]:
-            if ":" in address:
-                host, _port = address.split(":", 1)
-            else:
-                host = "0.0.0.0"
-                _port = address
+            """Parse address and return listening IP & port.
 
+            Accepts a port number or an IP & port string. Supports both IPv4
+            and IPv6.
+
+            Args:
+                address (str):
+                    Port to listen on (integer as a string) or an IP address
+                    (interface) and port to listen on.
+
+                    IP address and port should be separated by a colon (':').
+
+                    IPv6 address should be wrapped in square brakets ('[]').
+
+                    E.g.:
+                        '8080'                  (port only)
+                        '[dead::beef]:8080'     (IPv6 and port)
+                        '123.123.123.123:8080'  (IPv4 and port)
+
+            Returns:
+                tuple[str, int]:
+                    Tuple of IP address (interface) and port.
+
+                    If address=<port-only> then the address will default to
+                    '::' (i.e. all interfaces via IPv4 & IPv6).
+
+            Raises:
+                SimpleWebServerError:
+                    If address is malformed.
+
+            """
+            # Default to all interfaces, IPv4 & IPv6
+            host = "::"
+            # IPv6 with brackets: [::1]:8080
+            if address.startswith("["):
+                try:
+                    bracket_end = address.index("]")
+                except ValueError:
+                    raise SimpleWebServerError(
+                        f"Malformed IPv6 address: '{address}'"
+                        " - expected closing ']'",
+                    )
+                host = address[1:bracket_end]
+                rest = address[bracket_end + 1:]
+                if not rest.startswith(":"):
+                    raise SimpleWebServerError(
+                            f"Malformed address: '{address}'"
+                            " - expected ':port' after ']'",
+                        )
+                _port = rest[1:]
+            # IPv4 or bare port (no brackets, at most one colon)
+            elif address.count(":") == 1:
+                host, _port = address.split(":", 1)
+            # Bare port number only
+            else:
+                _port = address
             try:
                 port = int(_port)
                 assert port > 0 and port < 65535

--- a/bin/turnkey-init-fence
+++ b/bin/turnkey-init-fence
@@ -141,6 +141,12 @@ case "$1" in
         stop_mini_server
         echo "Stopped turnkey-init-fence"
         ;;
+    reload)
+        echo "Reloading turnkey-init-fence"
+        stop_mini_server
+        start_mini_server
+        echo "Reloaded turnkey-init-fence"
+        ;;
     *)
         echo "Unknown command: $1" >&2
         exit 1

--- a/bin/turnkey-init-fence
+++ b/bin/turnkey-init-fence
@@ -19,7 +19,10 @@ iptables_delete_redirect() {
     local to_port=$2
     echo "Removing REDIRECT firewall rule: $dport => $to_port"
     while true; do
-        (2>&1 iptables -t nat -D PREROUTING -p tcp --dport "$dport" -j REDIRECT --to-port "$to_port") > /dev/null || break
+        (2>&1 iptables -t nat -D PREROUTING -p tcp --dport "$dport" -j REDIRECT --to-port "$to_port") \
+            > /dev/null || break
+        (2>&1 ip6tables -t nat -D PREROUTING -p tcp --dport "$dport" -j REDIRECT --to-port "$to_port") \
+            > /dev/null || break
     done
 }
 
@@ -29,6 +32,7 @@ iptables_add_redirect() {
     echo "Adding REDIRECT firewall rule: $dport => $to_port"
     iptables_delete_redirect "$dport" "$to_port"
     iptables -t nat -A PREROUTING -p tcp --dport "$dport" -j REDIRECT --to-port "$to_port"
+    ip6tables -t nat -A PREROUTING -p tcp --dport "$dport" -j REDIRECT --to-port "$to_port"
 }
 
 iptables_unensure_accept() {
@@ -36,7 +40,10 @@ iptables_unensure_accept() {
     local dport=$1
     echo "Removing ACCEPT firewall rule for fence port: $dport"
     while true; do
-        (2>&1 iptables -t filter -D INPUT -p tcp -m tcp --dport "$dport" -j ACCEPT) > /dev/null || break
+        (2>&1 iptables -t filter -D INPUT -p tcp -m tcp --dport "$dport" -j ACCEPT) \
+            > /dev/null || break
+        (2>&1 ip6tables -t filter -D INPUT -p tcp -m tcp --dport "$dport" -j ACCEPT) \
+            > /dev/null || break
     done
 }
 
@@ -46,6 +53,7 @@ iptables_ensure_accept() {
     echo "Adding ACCEPT firewall rule for fence port: $dport"
     iptables_unensure_accept "$dport"
     iptables -t filter -A INPUT -p tcp -m tcp --dport "$dport" -j ACCEPT
+    ip6tables -t filter -A INPUT -p tcp -m tcp --dport "$dport" -j ACCEPT
 }
 
 iptables_redirect() {

--- a/debian/inithooks.turnkey-init-fence.service
+++ b/debian/inithooks.turnkey-init-fence.service
@@ -2,12 +2,13 @@
 Description=TurnKey Initialization web interface fence
 After=network.target network-online.target
 After=iptables.service firewalld.service ip6tables.service ipset.service nftables.service
-Before=apache2.service nginx.service lighttpd.service
+Before=apache2.service nginx.service lighttpd.service tomcat10.service tomcat11.service
 
 [Service]
 Type=oneshot
 RemainAfterExit=true
 ExecStart=/usr/lib/inithooks/bin/turnkey-init-fence start
+ExecReload=/usr/lib/inithooks/bin/turnkey-init-fence reload
 ExecStop=/usr/lib/inithooks/bin/turnkey-init-fence stop
 
 [Install]

--- a/firstboot.d/29tagid
+++ b/firstboot.d/29tagid
@@ -21,10 +21,11 @@ INITFENCE_INDEX="/var/$FENCE_INDEX"
 sed -i "s|@APP_NAME@|$APP_NAME|" $INITFENCE_INDEX
 
 if ! grep -q ajax.turnkeylinux.org $INITFENCE_INDEX; then
-
     cat>>$INITFENCE_INDEX<<EOF
 <script src="https://ajax.turnkeylinux.org/initfence/$BUILD/$VERSION/$APP_NAME.js" async></script>
 <script src="https://ajax.turnkeylinux.org/initfence/$BUILD/$VERSION/$APP_NAME.direct" async></script>
 EOF
-	
 fi
+
+# reload init-fence to pick up the updated index
+systemctl reload turnkey-init-fence

--- a/firstboot.d/30turnkey-init-fence
+++ b/firstboot.d/30turnkey-init-fence
@@ -2,12 +2,28 @@
 
 # Note that as of v19.0, the init-fence service is enabled by default
 
-[ -n "$_TURNKEY_INIT" ] && exit 0
+# Only run if AUTO_RUN is set (set by firstboot.d/29preseed on headless builds)
+# and not if called by turnkey-init
+if [[ -n "$_TURNKEY_INIT" ]]; then
+    exit 0
+elif [[ -z "$AUTO_RUN" ]]; then
+    logger -t inithooks "Skipping $(basename "$0") because AUTO_RUN not set"
+    exit 0
+fi
 
-USERNAME=root
+# shellcheck source=default/inithooks
+source /etc/default/inithooks
+if [[ -e "$INITHOOKS_CONF" ]]; then
+    # shellcheck disable=SC1090
+    source "$INITHOOKS_CONF"
+fi
 
-. /etc/default/inithooks
-[ "$(echo $SUDOADMIN | tr [A-Z] [a-z] )" = "true" ] && USERNAME=admin
+USERNAME="root"
+if [[ "${SUDOADMIN,,}" == "true" ]]; then
+    USERNAME="admin"
+fi
 
 PROFILE_FIRSTLOGIN=$(eval printf ~$USERNAME)/.profile.d/turnkey-init-fence
-[ -f $PROFILE_FIRSTLOGIN ] && chmod +x $PROFILE_FIRSTLOGIN
+if [[ -f "$PROFILE_FIRSTLOGIN" ]]; then
+    chmod +x "$PROFILE_FIRSTLOGIN"
+fi

--- a/firstboot.d/97turnkey-init-fence-disable
+++ b/firstboot.d/97turnkey-init-fence-disable
@@ -1,14 +1,16 @@
-#!/bin/bash
-
-[ -z "$_TURNKEY_INIT" ] && exit 0; # ONLY run from within turnkey-init
+#!/bin/bash -e
 
 systemctl disable turnkey-init-fence
 systemctl stop turnkey-init-fence
 
-for home in /root /home/admin; do
-    [ -e $home/.profile.d/turnkey-init-fence ] && chmod -x $home/.profile.d/turnkey-init-fence;
-done
+# ONLY run this from within turnkey-init
+    if [[ -n "$_TURNKEY_INIT" ]]; then
+    for home in /root /home/admin; do
+        if [[ -e $home/.profile.d/turnkey-init-fence ]]; then
+            chmod -x $home/.profile.d/turnkey-init-fence
+        fi
+    done
+    chmod -x /usr/lib/inithooks/firstboot.d/??turnkey-init-fence*
+fi
 
-chmod -x /usr/lib/inithooks/firstboot.d/??turnkey-init-fence*
-
-echo 'turnkey-init-fence is down'
+echo "turnkey-init-fence is down"

--- a/firstboot.d/97turnkey-init-fence-disable
+++ b/firstboot.d/97turnkey-init-fence-disable
@@ -2,10 +2,8 @@
 
 [ -z "$_TURNKEY_INIT" ] && exit 0; # ONLY run from within turnkey-init
 
-if systemctl is-active --quiet turnkey-init-fence; then
-    systemctl disable turnkey-init-fence
-    systemctl stop turnkey-init-fence
-fi
+systemctl disable turnkey-init-fence
+systemctl stop turnkey-init-fence
 
 for home in /root /home/admin; do
     [ -e $home/.profile.d/turnkey-init-fence ] && chmod -x $home/.profile.d/turnkey-init-fence;

--- a/firstboot.d/97turnkey-init-fence-disable
+++ b/firstboot.d/97turnkey-init-fence-disable
@@ -1,16 +1,29 @@
 #!/bin/bash -e
 
-systemctl disable turnkey-init-fence
-systemctl stop turnkey-init-fence
+# shellcheck source=default/inithooks
+source /etc/default/inithooks
+if [[ -e "$INITHOOKS_CONF" ]]; then
+    # shellcheck disable=SC1090
+    source "$INITHOOKS_CONF"
+fi
 
-# ONLY run this from within turnkey-init
-    if [[ -n "$_TURNKEY_INIT" ]]; then
+disable_init_fence() {
+    systemctl disable turnkey-init-fence
+    systemctl stop turnkey-init-fence
+    echo "turnkey-init-fence is down"
+}
+
+if [[ -n "$_TURNKEY_INIT" ]]; then
+    # ONLY run this from within turnkey-init
     for home in /root /home/admin; do
         if [[ -e $home/.profile.d/turnkey-init-fence ]]; then
             chmod -x $home/.profile.d/turnkey-init-fence
         fi
     done
     chmod -x /usr/lib/inithooks/firstboot.d/??turnkey-init-fence*
+    disable_init_fence
+elif [[ -z "$AUTO_RUN" ]]; then
+    # disable the init-fence if AUTO_RUN not set (set by firstboot.d/29preseed
+    # on headless builds)
+    disable_init_fence
 fi
-
-echo "turnkey-init-fence is down"

--- a/run
+++ b/run
@@ -28,15 +28,17 @@ mkdir -p "$(dirname "$INITHOOKS_LOGFILE")"
 touch "$INITHOOKS_LOGFILE"
 chmod 640 "$INITHOOKS_LOGFILE"
 
-# wait up to 10 secs for system to be running before starting; minimizes chance
-# of journal overwriting inithook dialog/confconsole
-logger -t inithooks "systemctl is-system-running: $(systemctl is-system-running)"
-for count in {1..10}; do
-    if [[ "$(systemctl is-system-running)" == "starting" ]]; then
-        logger -t inithooks "Waiting for boot to finish ($count/10 seconds)"
-        sleep 1
-    fi
-done
+wait_for_boot() {
+    # wait up to 10 secs for system to be running before starting; minimizes chance
+    # of journal overwriting inithook dialog/confconsole
+    logger -t inithooks "systemctl is-system-running: $(systemctl is-system-running)"
+    for count in {1..10}; do
+        if [[ "$(systemctl is-system-running)" == "starting" ]]; then
+            logger -t inithooks "Waiting for boot to finish ($count/10 seconds)"
+            sleep 1
+        fi
+    done
+}
 
 everyboot_ran() {
     # read lastboot time
@@ -90,6 +92,7 @@ fi
 
 exec_scripts() {
     local script_dir=$1
+    local firstboot=$2
     local script_executable=
     local script=
     [[ -d "$script_dir" ]] || return 0
@@ -102,6 +105,13 @@ exec_scripts() {
             source "$INITHOOKS_CONF"
         fi
         script=$(basename "$script_executable")
+        if [[ -n "$firstboot" ]]; then
+            # if firstboot, then only run <30 scripts - then wait
+            prefix="${script:0:2}"
+            if [[ $prefix =~ ^[0-9]+$ ]] && [[ $prefix -ge 30 ]]; then
+                wait_for_boot
+            fi
+        fi
         if [[ ! -x "$script_executable" ]]; then
             log warn "[$script] skipping"
             continue
@@ -128,7 +138,7 @@ exec_scripts() {
 
 if [[ "$RUN_FIRSTBOOT" == "true" ]]; then
     log info "Running firstboot scripts"
-    exec_scripts "$INITHOOKS_PATH/firstboot.d"
+    exec_scripts "$INITHOOKS_PATH/firstboot.d" firstboot
 fi
 
 if ! everyboot_ran; then


### PR DESCRIPTION
This PR is init-fence related - mostly directly:
- Update `simplehttpd.py` so it's "dual stack" (i.e. IPv4 & IPv6).
- Update `turnkey-init-fence` so that it sets/unsets IPv6 firewall rules too.
- Add support for `systemctl reload turnkey-init-fence` - reloads the webserver without touching the firewall rules - used by `29tagid` after updating `index.html`.
- Update `run` so that it will start running inithooks straight away but then wait once it gets the first `30...` inithook (all early hooks are non-interactive). This allows the init-fence page to be updated early, but still ensure that boot messages don't spam over the interactive hooks &/or confconsole.
- Refactored `30turnkey-init-fence` & `97turnkey-init-fence-disable` to account for when headless system is launched without preseeding. FYI when that happens the inithooks will run twice but we don't want the fence to come down until they interactively run the first boot hooks (the second time it runs).
- Update the readme in light of the changed fence functionality.

Also needs https://github.com/turnkeylinux/buildtasks/pull/96

This hasn't yet been extensively tested, but the package has been built and pushed to the `trixie-testing` repo.