### PR TITLE
Handle init-fence race condition

### DIFF
--- a/bin/simplehttpd.py
+++ b/bin/simplehttpd.py
@@ -22,22 +22,19 @@ Known bugs:
 
 """
 
-import os
-from os.path import exists, abspath, isdir, splitext
-from tempfile import NamedTemporaryFile
-import socket
-import sys
 import getopt
-from typing import NoReturn
-
+import grp
 import http.server
+import os
+import pwd
+import signal
+import socket
 import socketserver
 import ssl
-
-import pwd
-import grp
-
-import signal
+import sys
+from os.path import abspath, exists, isdir, splitext
+from tempfile import NamedTemporaryFile
+from typing import NoReturn
 
 
 class SimpleWebServerError(Exception):

--- a/bin/simplehttpd.py
+++ b/bin/simplehttpd.py
@@ -32,6 +32,7 @@ import socket
 import socketserver
 import ssl
 import sys
+import time
 from os.path import abspath, exists, isdir, splitext
 from tempfile import NamedTemporaryFile
 from typing import NoReturn
@@ -58,6 +59,39 @@ def usage(msg: str | getopt.GetoptError = "") -> NoReturn:
     assert __doc__ is not None
     print(__doc__.strip(), file=sys.stderr)
     sys.exit(1)
+
+
+def wait_for_valid_cert(
+        certfile: str,
+        keyfile: str | None = None,
+        timeout: int = 30,
+        interval: float = 0.5,
+    ) -> None:
+    """Wait until certfile and keyfile exist and are a matching pair.
+
+    If keyfile is None, certfile is expected to contain both cert and key.
+    """
+    deadline = time.monotonic() + timeout
+
+    files_to_check = [f for f in (certfile, keyfile) if f is not None]
+
+    while time.monotonic() < deadline:
+        try:
+            # Relevant file/s must exist and be non-empty
+            if not all(os.path.getsize(f) > 0 for f in files_to_check):
+                time.sleep(interval)
+                continue
+
+            # Try loading it/them
+            ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+            ctx.load_cert_chain(certfile=certfile, keyfile=keyfile)
+            return  # Success
+        except (ssl.SSLError, OSError):
+            time.sleep(interval)
+    raise TimeoutError(
+        f"Timed out after {timeout}s waiting for a valid cert/key pair: "
+        f"{certfile}, {keyfile}"
+    )
 
 
 def is_writeable(path: str) -> bool:
@@ -397,6 +431,12 @@ def main():
 
     signal.signal(signal.SIGHUP, sighandler)
     signal.signal(signal.SIGTERM, sighandler)
+
+    try:
+        # ensure cert generation has finished
+        wait_for_valid_cert(certfile, keyfile)
+    except TimeoutError as e:
+        fatal(e)
 
     server = SimpleWebServer(webroot, http_address, https_conf, runas)
     if daemonize_pidfile:

--- a/bin/turnkey-init-fence
+++ b/bin/turnkey-init-fence
@@ -142,9 +142,12 @@ case "$1" in
         echo "Stopped turnkey-init-fence"
         ;;
     post-stop)
-        echo "Post-stop cleanup for turnkey-init-fence"
-        iptables_redirect stop
-        echo "Firewall rules removed"
+        # SERVICE_RESULT is set by systemd
+        if [[ "$SERVICE_RESULT" != "success" ]]; then
+            echo "Post-stop cleanup for failed turnkey-init-fence"
+            iptables_redirect stop
+            echo "Firewall rules removed"
+        fi
         ;;
     reload)
         echo "Reloading turnkey-init-fence"

--- a/bin/turnkey-init-fence
+++ b/bin/turnkey-init-fence
@@ -141,7 +141,7 @@ case "$1" in
         stop_mini_server
         echo "Stopped turnkey-init-fence"
         ;;
-    post-stop)
+    stop-post)
         # SERVICE_RESULT is set by systemd
         if [[ "$SERVICE_RESULT" != "success" ]]; then
             echo "Post-stop cleanup for failed turnkey-init-fence"

--- a/bin/turnkey-init-fence
+++ b/bin/turnkey-init-fence
@@ -141,6 +141,11 @@ case "$1" in
         stop_mini_server
         echo "Stopped turnkey-init-fence"
         ;;
+    post-stop)
+        echo "Post-stop cleanup for turnkey-init-fence"
+        iptables_redirect stop
+        echo "Firewall rules removed"
+        ;;
     reload)
         echo "Reloading turnkey-init-fence"
         stop_mini_server

--- a/debian/inithooks.turnkey-init-fence.service
+++ b/debian/inithooks.turnkey-init-fence.service
@@ -5,11 +5,13 @@ After=iptables.service firewalld.service ip6tables.service ipset.service nftable
 Before=apache2.service nginx.service lighttpd.service tomcat10.service tomcat11.service
 
 [Service]
-Type=oneshot
+Type=forking
+PIDFile=/run/init-fence.pid
 RemainAfterExit=true
 ExecStart=/usr/lib/inithooks/bin/turnkey-init-fence start
 ExecReload=/usr/lib/inithooks/bin/turnkey-init-fence reload
 ExecStop=/usr/lib/inithooks/bin/turnkey-init-fence stop
+ExecStopPost=/usr/lib/inithooks/bin/turnkey-init-fence stop-post
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
@OnGle - I couldn't reproduce the issue you reported offline. But I tested on a low resource VM so I'm guessing that it's a race condition where host resources is a factor.

As `ssl.SSLError: [X509: KEY_VALUES_MISMATCH] key values mismatch (_ssl.c:4108)` suggests, the issue appears to be mismatching SSL cert/key pair.

My guess is that there was a race condition where the firstboot SSL cert regeneration is not complete when the `simplehttpd.py` mini-server started - so the cert is the freshly generated one but the key is still the old one (or vice versa?).

Working on that basis, `simplehttpd.py` now checks whether the cert & key exist _and_ that they match, with a 30sec timeout (which is probably way too generous).

As you noted, the knock on effect of `simplehttpd.py` crashing was that the firewall rules weren't torn down.

TBH I'm not 100% sure if the way I ensured the firewall rules are torn down regardless of `simplehttpd.py` exit state are the best way to go, but they should be robust enough.

FWIW initially I was going to put a trap in the `turnkey-init-fence` script, but obviously that won't work (`simplehttpd.py` daemonizes). So then I started playing around in `turnkey-init-fence`, trying to handle/check the PID, but that started getting complicated - and perhaps may still not have worked properly. So leveraging systemd was a simpler way to handle it as `ExecStopPost=` always runs regardless of whether `ExecStart=` fails or not. systemd set `SERVICE_RESULT` so the separate firewall rule teardown only occurs if starting `simplehttpd.py` (or `turnkey-init-fence`) fails.