### PR TITLE
Refactoring: everyboot flow and init-fence

### DIFF
--- a/bin/turnkey-init-fence
+++ b/bin/turnkey-init-fence
@@ -6,13 +6,17 @@
 DEBUG=${DEBUG:-}
 [[ -z "$DEBUG" ]] || set -x
 
-HTDOCS=lib/inithooks/turnkey-init-fence/htdocs
 PIDFILE=/run/init-fence.pid
 LOGFILE=/var/log/init-fence.log
-SERVER_RUNAS=nobody
 
 # shellcheck source=default/turnkey-init-fence
 source /etc/default/turnkey-init-fence
+
+# firstboot.d/29tagid creates $HTDOCS if it doesn't exist, but fallback to
+# packaged htdocs so fence doesn't fail if it doesn't (yet) exist
+if [[ ! -d "$HTDOCS" ]]; then
+    HTDOCS="/usr/lib/inithooks/turnkey-init-fence/htdocs"
+fi
 
 iptables_delete_redirect() {
     local dport=$1
@@ -88,20 +92,16 @@ iptables_redirect() {
 }
 
 start_mini_server() {
-    local htdocs
-    if [[ -d "/var/$HTDOCS" ]]; then
-        htdocs="/var/$HTDOCS"
-    else
-        htdocs="/usr/$HTDOCS"
-    fi
-    echo "Starting init-fence mini-server (serving $htdocs)"
+    echo "Starting init-fence mini-server (serving $HTDOCS)"
     touch "$LOGFILE" "$PIDFILE"
-    chown -R "$SERVER_RUNAS" "$htdocs" "$LOGFILE" "$PIDFILE"
+    chown -R "$RUNAS" "$HTDOCS" "$LOGFILE" "$PIDFILE"
+    find "$HTDOCS" -type d -exec chmod 0555 {} \;
+    find "$HTDOCS" -type f -exec chmod 0444 {} \;
     /usr/lib/inithooks/bin/simplehttpd.py \
         --daemonize="$PIDFILE" \
-        --runas="$SERVER_RUNAS" \
+        --runas="$RUNAS" \
         --logfile="$LOGFILE" \
-        "$htdocs" \
+        "$HTDOCS" \
         "$HTTP_FENCE_PORT" \
         "$HTTPS_FENCE_PORT" \
         "$HTTPS_FENCE_CERTFILE" \

--- a/bin/turnkey-init-fence
+++ b/bin/turnkey-init-fence
@@ -18,11 +18,13 @@ iptables_delete_redirect() {
     local dport=$1
     local to_port=$2
     echo "Removing REDIRECT firewall rule: $dport => $to_port"
-    while true; do
-        (2>&1 iptables -t nat -D PREROUTING -p tcp --dport "$dport" -j REDIRECT --to-port "$to_port") \
-            > /dev/null || break
-        (2>&1 ip6tables -t nat -D PREROUTING -p tcp --dport "$dport" -j REDIRECT --to-port "$to_port") \
-            > /dev/null || break
+    while iptables -t nat -D PREROUTING -p tcp --dport "$dport" \
+            -j REDIRECT --to-port "$to_port" 2>/dev/null; do
+        :
+    done
+    while ip6tables -t nat -D PREROUTING -p tcp --dport "$dport" \
+            -j REDIRECT --to-port "$to_port" 2>/dev/null; do
+        :
     done
 }
 
@@ -39,11 +41,13 @@ iptables_unensure_accept() {
     # Used in appliances that have a `filter` policy of `DROP`
     local dport=$1
     echo "Removing ACCEPT firewall rule for fence port: $dport"
-    while true; do
-        (2>&1 iptables -t filter -D INPUT -p tcp -m tcp --dport "$dport" -j ACCEPT) \
-            > /dev/null || break
-        (2>&1 ip6tables -t filter -D INPUT -p tcp -m tcp --dport "$dport" -j ACCEPT) \
-            > /dev/null || break
+    while iptables -t filter -D INPUT -p tcp -m tcp \
+            --dport "$dport" -j ACCEPT 2>/dev/null; do
+        :
+    done
+    while ip6tables -t filter -D INPUT -p tcp -m tcp \
+            --dport "$dport" -j ACCEPT 2>/dev/null; do
+        :
     done
 }
 

--- a/debian/inithooks.service
+++ b/debian/inithooks.service
@@ -1,7 +1,5 @@
 [Unit]
 Description=Run boot scripts and start confconsole on tty1
-# ensure inithooks only runs once per boot
-ConditionPathExists=!/run/inithooks-complete
 # kill getty service if it's running
 Conflicts=getty@tty1.service container-getty@1.service
 After=getty.target getty@tty1.service container-getty@1.service
@@ -12,8 +10,6 @@ OnFailure=inithooks-restart-getty1.service
 [Service]
 Type=exec
 ExecStart=/usr/lib/inithooks/run
-# ensure inithooks only runs once per boot
-ExecStartPost=/usr/bin/touch /run/inithooks-complete
 # (re)start getty1 if inithooks.service exits cleanly
 ExecStopPost=/bin/systemctl start inithooks-restart-getty1.service
 

--- a/debian/inithooks.turnkey-init-fence.service
+++ b/debian/inithooks.turnkey-init-fence.service
@@ -5,8 +5,7 @@ After=iptables.service firewalld.service ip6tables.service ipset.service nftable
 Before=apache2.service nginx.service lighttpd.service tomcat10.service tomcat11.service
 
 [Service]
-Type=forking
-PIDFile=/run/init-fence.pid
+Type=oneshot
 RemainAfterExit=true
 ExecStart=/usr/lib/inithooks/bin/turnkey-init-fence start
 ExecReload=/usr/lib/inithooks/bin/turnkey-init-fence reload

--- a/debian/postinst
+++ b/debian/postinst
@@ -2,33 +2,36 @@
 
 set -e
 
-mkdir -p /var/run/turnkey-init-fence
-if [ -f /etc/default/turnkey-init-fence ]; then
-    RUNAS=$(sed -n 's/^RUNAS=//p' /etc/default/turnkey-init-fence)
-    if [ -n "$RUNAS" ]; then
-        chown -R "$RUNAS" /var/run/turnkey-init-fence
-    fi
-fi
-
-if [ "$1" = "configure" ]; then
+if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] \
+        || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then
+    systemctl daemon-reload >/dev/null || true
     if [ -n "$2" ]; then
         # this is an upgrade ($2 is the old version)
-        # /run/inithooks-was-active is created by preinst script if relevant
-        if [ -f /run/inithooks-was-active ]; then
+        # systemctl restart will start services if not running
+
+        # /run/_service_-was-active is created by preinst script
+        if [ -f "/run/inithooks-was-active" ]; then
             rm -f /run/inithooks-was-active
-            systemctl start inithooks.service
+            # restart will start if not running
+            systemctl restart inithooks.service
+            # unlikely that turnkey-init-fence is running when package is
+            # upgraded but just in case
+            if [ -f "/run/turnkey-init-fence-was-active" ]; then
+                rm -f /run/turnkey-init-fence-was-active
+                systemctl restart turnkey-init-fence.service
+            fi
         else
-            systemctl start getty@tty1.service container-getty@1.service 2>/dev/null || true
+            # getty1 should already be running if inithooks wasn't, but let's
+            # make sure
+            systemctl restart getty@tty1.service container-getty@1.service 2>/dev/null || true
         fi
     else
-        # fresh install ($2 is empty)
-        systemctl daemon-reload
+        # fresh install ($2 is empty) - enable services
         systemctl enable inithooks.service
+        systemctl enable turnkey-init-fence.service
     fi
 fi
 
 chmod 755 /usr/lib/inithooks/bin/inithooks_cache.py
-
-#DEBHELPER#
 
 exit 0

--- a/debian/postinst
+++ b/debian/postinst
@@ -10,6 +10,23 @@ if [ -f /etc/default/turnkey-init-fence ]; then
     fi
 fi
 
+if [ "$1" = "configure" ]; then
+    if [ -n "$2" ]; then
+        # this is an upgrade ($2 is the old version)
+        # /run/inithooks-was-active is created by preinst script if relevant
+        if [ -f /run/inithooks-was-active ]; then
+            rm -f /run/inithooks-was-active
+            systemctl start inithooks.service
+        else
+            systemctl start getty@tty1.service container-getty@1.service 2>/dev/null || true
+        fi
+    else
+        # fresh install ($2 is empty)
+        systemctl daemon-reload
+        systemctl enable inithooks.service
+    fi
+fi
+
 chmod 755 /usr/lib/inithooks/bin/inithooks_cache.py
 
 #DEBHELPER#

--- a/debian/preinst
+++ b/debian/preinst
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+
+if [ "$1" = "upgrade" ]; then
+    if systemctl is-active -q inithooks.service; then
+        touch /run/inithooks-was-active
+    fi
+fi

--- a/debian/preinst
+++ b/debian/preinst
@@ -3,7 +3,9 @@
 set -e
 
 if [ "$1" = "upgrade" ]; then
-    if systemctl is-active -q inithooks.service; then
-        touch /run/inithooks-was-active
-    fi
+    for service in inithooks turnkey-init-fence; do
+        if systemctl is-active -q "$service.service"; then
+            touch "/run/$service-was-active"
+        fi
+    done
 fi

--- a/default/turnkey-init-fence
+++ b/default/turnkey-init-fence
@@ -1,4 +1,7 @@
-WEBROOT=/usr/lib/inithooks/turnkey-init-fence/htdocs
+# if this path does not exist, /usr/lib/inithooks/turnkey-init-fence/htdocs
+# is used as a fallback
+HTDOCS=/var/lib/inithooks/turnkey-init-fence/htdocs
+
 HTTP_PORTS=(80)
 HTTPS_PORTS=(443 12321 12322)
 

--- a/firstboot.d/29tagid
+++ b/firstboot.d/29tagid
@@ -8,16 +8,15 @@ BUILD=$(perl -ne 'chomp; s/.*\((.*)\).*/\1/; s/^\S+ ?//; $tags=$_ ? $_ : "iso"; 
 
 ### initfence 
 
-FENCE_DIR=lib/inithooks/turnkey-init-fence
-FENCE_HTDOCS="$FENCE_DIR/htdocs"
-FENCE_INDEX="$FENCE_HTDOCS/index.html"
+# shellcheck source=default/turnkey-init-fence
+source /etc/default/turnkey-init-fence
 
-if [[ ! -d "/var/$FENCE_DIR" ]]; then
-    mkdir -p "/var/$FENCE_DIR"
-    cp -R "/usr/$FENCE_HTDOCS" "/var/$FENCE_DIR/"
+if [[ ! -d "$HTDOCS" ]]; then
+    mkdir -p "$(dirname "$HTDOCS")"
+    cp -R "/usr/lib/inithooks/turnkey-init-fence/htdocs" "$(dirname "$HTDOCS")"
 fi
 
-INITFENCE_INDEX="/var/$FENCE_INDEX"
+INITFENCE_INDEX="$HTDOCS/index.html"
 sed -i "s|@APP_NAME@|$APP_NAME|" $INITFENCE_INDEX
 
 if ! grep -q ajax.turnkeylinux.org $INITFENCE_INDEX; then

--- a/run
+++ b/run
@@ -40,30 +40,6 @@ wait_for_boot() {
     done
 }
 
-everyboot_ran() {
-    # read lastboot time
-    lastboot_time="$(date '+%s' -d "$(cut -f1 -d. /proc/uptime) seconds ago")"
-    if [[ -f /run/inithooks/everyboot_ran ]]; then
-        # time stamp written
-        prev_lastboot_time="$(</run/inithooks/everyboot_ran)"
-        if [[ "$lastboot_time" -eq "$prev_lastboot_time" ]]; then
-            # time stamp of last boot is the same as our last boot, everyboot
-            # scripts already ran
-            return 0
-        else
-            # time stamp of last boot is different from our last boot, everyboot
-            # scripts not already ran
-            echo "$lastboot_time" > /run/inithooks/everyboot_ran
-            return 1
-        fi
-    else
-        # no time stamp written, haven't run everyboot scripts since last boot
-        mkdir -p /run/inithooks
-        echo "$lastboot_time" > /run/inithooks/everyboot_ran
-        return 1
-    fi
-}
-
 log() {
     # log to journal as well as $INITHOOKS_LOGFILE
     local level=$1 # err|warn|info|debug
@@ -135,15 +111,16 @@ exec_scripts() {
     return 0
 }
 
-
 if [[ "$RUN_FIRSTBOOT" == "true" ]]; then
     log info "Running firstboot scripts"
     exec_scripts "$INITHOOKS_PATH/firstboot.d" firstboot
 fi
 
-if ! everyboot_ran; then
+# ensure everyboot scripts only run once per boot
+if [[ ! -f /run/inithooks-complete ]]; then
     log info "Running everyboot scripts"
     exec_scripts "$INITHOOKS_PATH/everyboot.d"
+    touch /run/inithooks-complete
 fi
 
 if [[ -n "$PID" ]];  then


### PR DESCRIPTION
- refactor everyboot functionality/flow to make more robust and avoid unexpected issues
- refactor init-fence to (somewhat) simplify and ensure consistanty within codebase
- refactor package maintainer scripts - inc replace `#DEBHELPER#` section with manual config

Please note that I'm a bit pressed for time ATM but wanted @OnGle to have a look ASAP so I haven't yet tested this as much a I would like... When I get a chance - and before I push it to the repos - I will do some more testing.