### PR TITLE
Release notes

### DIFF
--- a/release_notes/RelNotes-2.3.1.txt
+++ b/release_notes/RelNotes-2.3.1.txt
@@ -1,4 +1,4 @@
-v2.3.0 Release Notes
+v2.3.1 Release Notes
 ====================
 
 Trixie updates, bugfixes, refactoring and code quality updates.

--- a/release_notes/RelNotes-2.3.2.txt
+++ b/release_notes/RelNotes-2.3.2.txt
@@ -1,0 +1,26 @@
+v2.3.2 Release Notes
+====================
+
+Bugfix and make service/s more robust.
+
+* Bugfixes:
+  - simplehttpd.py
+    - Handle certificate/key mismatch corner case.
+
+* Improvements:
+  - init-fence
+    - Handle ipv4 & ipv6 firewall rules separately to avoid risk of single
+      failure causing other rules to not be applied/torn down.
+    - Ensure service tears down firewall rules, even if turnkey-init-fence or
+      simplehttpd.py fail.
+    - Tidy up of init-fence code. Includes refatoring of:
+        - default/turnkey-init-fence
+        - firstboot.d/29tagid
+        - bin/turnkey-init-fence
+        - turnkey-init-fence.service
+        - inithooks.service (debian/inithooks.turnkey-init-fence.service)
+    - Move all everyboot management to run script and reduce complexity.
+
+  - Debian packaging:
+    - Replace auto-generated postint components with explicit code to ensure
+      desired functionality.


### PR DESCRIPTION
Renamed `v2.3.0` release notes to `v2.3.1` (same version - version bumped to `v2.3.1` due to mistake with RC versioning - mistake resulted in `v2.3.0rcX` RC versions being considered later versions that the stable `v2.3.0`).

Added `v2.3.2` release notes.

@OnGle - seeing as this is only a release notes updae, I'm going to merge it straight away and push the updated package to the trixie main repos.