### PR TITLE
Ensure conconsole screen is not overwritten on reboot

### DIFF
--- a/run
+++ b/run
@@ -131,6 +131,8 @@ fi
 if [[ "$REDIRECT_OUTPUT" == "true" ]]; then
     log info "Inithook run completed, exiting."
 else
+    # ensure confconsole --usage isn't overwritten on reboots
+    wait_for_boot
     log info "Inithook run completed, now starting confconsole"
     sleep 2 # anyway to replace this?
     confconsole --usage


### PR DESCRIPTION
Use of the `wait_for_boot` on first boot works pretty well, however I've noticed that on subsequent boots confconsole often gets overwritten by a couple of messages. This tweak resolves that.